### PR TITLE
Implement blog pagination

### DIFF
--- a/components/util/pagination.tsx
+++ b/components/util/pagination.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import Link from "next/link";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+}
+
+export const Pagination = ({ currentPage, totalPages }: PaginationProps) => {
+  const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const prevPage = currentPage > 1 ? currentPage - 1 : null;
+  const nextPage = currentPage < totalPages ? currentPage + 1 : null;
+
+  const getHref = (page: number) => {
+    return page === 1 ? "/blogs" : `/blogs/page/${page}`;
+  };
+
+  return (
+    <nav className="flex justify-center items-center mt-8 space-x-2" aria-label="Pagination">
+      {prevPage && (
+        <Link href={getHref(prevPage)} className="px-3 py-1 border rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
+          Previous
+        </Link>
+      )}
+      {pageNumbers.map((page) => (
+        <Link
+          key={page}
+          href={getHref(page)}
+          className={`px-3 py-1 border rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 ${page === currentPage ? "bg-gray-200 dark:bg-gray-700" : ""}`}
+        >
+          {page}
+        </Link>
+      ))}
+      {nextPage && (
+        <Link href={getHref(nextPage)} className="px-3 py-1 border rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
+          Next
+        </Link>
+      )}
+    </nav>
+  );
+};

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -57,7 +57,7 @@ export default function BlogsIndex(
 
 export const getStaticProps = async () => {
   const tinaProps = await client.queries.blogPageQuery();
-  const totalPosts = tinaProps.data.blogConnection.edges.length;
+  const totalPosts = tinaProps?.data?.blogConnection?.edges?.length ?? 0;
   const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
   return {
     props: {

--- a/pages/blogs/page/[page].tsx
+++ b/pages/blogs/page/[page].tsx
@@ -1,23 +1,22 @@
 import React from "react";
-import { Container } from "../../components/util/container";
-import { Section } from "../../components/util/section";
-import { client } from "../../tina/__generated__/client";
-import { Layout } from "../../components/layout";
-import { Blogs } from "../../components/posts/blogs";
-import { Pagination } from "../../components/util/pagination";
+import { Container } from "../../../components/util/container";
+import { Section } from "../../../components/util/section";
+import { client } from "../../../tina/__generated__/client";
+import { Layout } from "../../../components/layout";
+import { Blogs } from "../../../components/posts/blogs";
+import { Pagination } from "../../../components/util/pagination";
 import { InferGetStaticPropsType } from "next";
 import Head from "next/head";
 
 const POSTS_PER_PAGE = 5;
 
-export default function BlogsIndex(
+export default function BlogsPage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
   const blogs = props.data.blogConnection.edges ?? [];
   const { currentPage, totalPages } = props;
-  const pageTitle = "Brady Stroud | Blog";
+  const pageTitle = `Brady Stroud | Blog - Page ${currentPage}`;
 
-  // Sort blogs by date (newest first)
   const sortedBlogs = [...blogs].sort((a, b) => {
     const dateA = new Date(a?.node?.date || 0);
     const dateB = new Date(b?.node?.date || 0);
@@ -34,7 +33,7 @@ export default function BlogsIndex(
         <meta property="og:title" content={pageTitle} />
         <link
           rel="canonical"
-          href="https://bradystroud.dev/blogs"
+          href={`https://bradystroud.dev/blogs/page/${currentPage}`}
           key="canonical"
         />
       </Head>
@@ -44,8 +43,7 @@ export default function BlogsIndex(
             <h1 className="text-4xl title-font mb-4">Blogs</h1>
           </div>
           <p className="text-gray-600 text-lg pb-5 italic">
-            Learning from your mistakes is cool, but if you can learn from
-            other peoples mistakes, that's even cooler. Thats why you should read my blogs - a collection of past learnings.
+            Learning from your mistakes is cool, but if you can learn from other peoples mistakes, that's even cooler. Thats why you should read my blogs - a collection of past learnings.
           </p>
           <Blogs data={paginatedBlogs} />
           <Pagination currentPage={currentPage} totalPages={totalPages} />
@@ -55,15 +53,36 @@ export default function BlogsIndex(
   );
 }
 
-export const getStaticProps = async () => {
+export const getStaticProps = async ({ params }) => {
   const tinaProps = await client.queries.blogPageQuery();
   const totalPosts = tinaProps.data.blogConnection.edges.length;
   const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
+  const currentPage = parseInt(params.page as string, 10);
+
+  if (currentPage < 1 || currentPage > totalPages) {
+    return { notFound: true };
+  }
+
   return {
     props: {
       ...tinaProps,
-      currentPage: 1,
+      currentPage,
       totalPages,
     },
+  };
+};
+
+export const getStaticPaths = async () => {
+  const tinaProps = await client.queries.blogPageQuery();
+  const totalPosts = tinaProps.data.blogConnection.edges.length;
+  const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
+
+  const paths = Array.from({ length: totalPages - 1 }, (_, i) => ({
+    params: { page: String(i + 2) },
+  }));
+
+  return {
+    paths,
+    fallback: false,
   };
 };

--- a/pages/blogs/page/[page].tsx
+++ b/pages/blogs/page/[page].tsx
@@ -55,7 +55,7 @@ export default function BlogsPage(
 
 export const getStaticProps = async ({ params }) => {
   const tinaProps = await client.queries.blogPageQuery();
-  const totalPosts = tinaProps.data.blogConnection.edges.length;
+  const totalPosts = tinaProps?.data?.blogConnection?.edges?.length ?? 0;
   const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
   const currentPage = parseInt(params.page as string, 10);
 
@@ -74,7 +74,7 @@ export const getStaticProps = async ({ params }) => {
 
 export const getStaticPaths = async () => {
   const tinaProps = await client.queries.blogPageQuery();
-  const totalPosts = tinaProps.data.blogConnection.edges.length;
+  const totalPosts = tinaProps?.data?.blogConnection?.edges?.length ?? 0;
   const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
 
   const paths = Array.from({ length: totalPages - 1 }, (_, i) => ({


### PR DESCRIPTION
## Summary
- paginate blog listing 5 posts per page
- add a generic Pagination component
- expose additional pages at `/blogs/page/[page]`

## Testing
- `pnpm build` *(fails: Client not configured properly)*

------
https://chatgpt.com/codex/tasks/task_e_6840d562aa7883279eba2d80040149be