### PR TITLE
Fix blog list anchors

### DIFF
--- a/components/posts/blogs.tsx
+++ b/components/posts/blogs.tsx
@@ -24,7 +24,7 @@ export const Blogs = ({ data }) => {
             passHref
             legacyBehavior
           >
-            <div
+            <a
               key={post.id}
               className="group block px-6 sm:px-8 md:px-10 py-10 mb-8 last:mb-0 bg-gray-50 bg-linear-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-1000 rounded-md shadow-xs transition-all duration-150 ease-out hover:shadow-md hover:to-gray-50 dark:hover:to-gray-800 hover:cursor-pointer"
             >
@@ -48,7 +48,7 @@ export const Blogs = ({ data }) => {
                   </>
                 )}
               </div>
-            </div>
+            </a>
           </Link>
         );
       })}


### PR DESCRIPTION
## Summary
- change blog listing to use `<a>` tags instead of clickable `<div>` containers

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config)*
- `pnpm build` *(fails: fetch failed during Tina build)*

------
https://chatgpt.com/codex/tasks/task_e_686726dad27483279fa23f3296a634df