### PR TITLE
Add nofollow for external Markdown links

### DIFF
--- a/components/blocks/content.tsx
+++ b/components/blocks/content.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { MarkdownLink } from "../util/markdownLink";
 import { Template } from "tinacms";
 
 export const Content = ({ data, parentField = "" }) => {
@@ -15,7 +16,7 @@ export const Content = ({ data, parentField = "" }) => {
         size="large"
         width="medium"
       >
-        <TinaMarkdown content={data.body} />
+        <TinaMarkdown content={data.body} components={{ a: MarkdownLink }} />
       </Container>
     </Section>
   );

--- a/components/blocks/hero.tsx
+++ b/components/blocks/hero.tsx
@@ -3,6 +3,7 @@ import { Actions } from "../util/actions";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { MarkdownLink } from "../util/markdownLink";
 import type { Template } from "tinacms";
 import Image from "next/image";
 
@@ -38,7 +39,7 @@ export const Hero = ({ data, parentField }) => {
                 data.color === "primary" ? `prose-primary` : `dark:prose-dark`
               }`}
             >
-              <TinaMarkdown content={data.text} />
+              <TinaMarkdown content={data.text} components={{ a: MarkdownLink }} />
             </div>
           )}
           {data.actions && (

--- a/components/blocks/projects.tsx
+++ b/components/blocks/projects.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { Template } from "tinacms";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { MarkdownLink } from "../util/markdownLink";
 import { HoverCard } from "../util/hoverCard";
 
 export const Project = ({ data, tinaField, index }) => {
@@ -54,6 +55,7 @@ export const Projects = ({ data, parentField }) => {
           <TinaMarkdown
             content={data.body}
             data-tinafield={`${parentField}.body`}
+            components={{ a: MarkdownLink }}
           />
         </div>
         <div className={`flex flex-wrap gap-x-10 gap-y-8 text-left`}>

--- a/components/layout/breadcrumb.tsx
+++ b/components/layout/breadcrumb.tsx
@@ -23,7 +23,6 @@ function cleanUpLink(link: string) {
 const NextBreadcrumb = () => {
   const paths = usePathname();
   const pathNames = paths.split("/").filter((path) => path);
-  const separator = <span className="mx-2">/</span>;
   return (pathNames.length > 0 && (<div className="mx-20">
     <ul className="flex py-5">
       <li className="hover:opacity-70 hover:underline mx-2">

--- a/components/util/markdownLink.tsx
+++ b/components/util/markdownLink.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Link from "next/link";
+
+interface MarkdownLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  url?: string;
+  children?: React.ReactNode;
+}
+
+export const MarkdownLink: React.FC<MarkdownLinkProps> = ({ url = "", children, ...rest }) => {
+  const isExternal = /^https?:\/\//i.test(url);
+  if (isExternal) {
+    return (
+      <a href={url} target="_blank" rel="nofollow" {...rest}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={url} {...rest}>
+      {children}
+    </Link>
+  );
+};

--- a/components/util/markdownLink.tsx
+++ b/components/util/markdownLink.tsx
@@ -10,7 +10,7 @@ export const MarkdownLink: React.FC<MarkdownLinkProps> = ({ url = "", children, 
   const isExternal = /^https?:\/\//i.test(url);
   if (isExternal) {
     return (
-      <a href={url} target="_blank" rel="nofollow" {...rest}>
+      <a href={url} target="_blank" rel="nofollow noopener" {...rest}>
         {children}
       </a>
     );

--- a/pages/blogs/[filename].tsx
+++ b/pages/blogs/[filename].tsx
@@ -5,6 +5,7 @@ import { Layout } from "../../components/layout";
 import { Section } from "../../components/util/section";
 import { Container } from "../../components/util/container";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { MarkdownLink } from "../../components/util/markdownLink";
 import { InferGetStaticPropsType } from "next";
 import Image from "next/image";
 import Head from "next/head";
@@ -80,7 +81,10 @@ export default function Blog(
           </Container>
           <Container className={`flex-1 pt-4`} width="small" size="large">
             <div className="prose dark:prose-dark w-full max-w-none">
-              <TinaMarkdown content={data.blog._body} />
+              <TinaMarkdown
+                content={data.blog._body}
+                components={{ a: MarkdownLink }}
+              />
             </div>
             <div>
               <Giscus

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const matter = require('gray-matter');
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
 
 const siteUrl = 'https://bradystroud.dev';
 const blogsDir = path.resolve(process.cwd(), 'content', 'blogs');
@@ -29,13 +29,14 @@ const items: RssItem[] = files.flatMap(file => {
 
     const slug = file.replace(/\.mdx?$/, '');
 
-    // description: front‑matter excerpt → description → first paragraph
+    // description: front-matter excerpt -> description -> first paragraph
     const desc = (data.excerpt ?? data.description ?? '') ||
         content.split(/\r?\n\r?\n/)            // paragraphs
             .find(p => p.trim())!                // first non‑empty
             .replace(/\n+/g, ' ')
             .replace(/\.([A-Za-z])/g, '. $1')    // '.I' → '. I'
-            .replace(/[#*_`>\[\]\(\)!]/g, '')    // strip md
+            // eslint-disable-next-line no-useless-escape
+            .replace(/[#*_`>\[\]()!]/g, '')    // strip md
             .replace(/\s+/g, ' ')
             .trim();
 
@@ -50,9 +51,9 @@ const items: RssItem[] = files.flatMap(file => {
 const rss = `<?xml version="1.0" encoding="UTF-8"?>
    <rss version="2.0">
    <channel>
-   <title>Brady Stroud Blog</title>
+   <title>Brady Stroud Blog</title>
    <link>${siteUrl}</link>
-   <description>Latest posts from Brady Stroud</description>
+   <description>Latest posts from Brady Stroud</description>
    ${items
         .sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
         .map(i => `


### PR DESCRIPTION
## Summary
- add MarkdownLink component to mark external links `rel="nofollow"` and open in new tab
- use MarkdownLink in content blocks and blog posts
- clean up breadcrumb unused variable
- fix script lint errors
- use Next.js Link for internal Markdown links

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686aea26b4e08327abbcc8bc3569c617