### PR TITLE
Enable Prism-based code highlighting

### DIFF
--- a/components/blocks/content.tsx
+++ b/components/blocks/content.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { Prism } from "tinacms/dist/rich-text/prism";
 import { Template } from "tinacms";
 
 export const Content = ({ data, parentField = "" }) => {
@@ -15,7 +16,7 @@ export const Content = ({ data, parentField = "" }) => {
         size="large"
         width="medium"
       >
-        <TinaMarkdown content={data.body} />
+        <TinaMarkdown content={data.body} components={{ code_block: Prism }} />
       </Container>
     </Section>
   );

--- a/components/blocks/hero.tsx
+++ b/components/blocks/hero.tsx
@@ -3,6 +3,7 @@ import { Actions } from "../util/actions";
 import { Container } from "../util/container";
 import { Section } from "../util/section";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { Prism } from "tinacms/dist/rich-text/prism";
 import type { Template } from "tinacms";
 import Image from "next/image";
 
@@ -38,7 +39,10 @@ export const Hero = ({ data, parentField }) => {
                 data.color === "primary" ? `prose-primary` : `dark:prose-dark`
               }`}
             >
-              <TinaMarkdown content={data.text} />
+              <TinaMarkdown
+                content={data.text}
+                components={{ code_block: Prism }}
+              />
             </div>
           )}
           {data.actions && (

--- a/components/blocks/projects.tsx
+++ b/components/blocks/projects.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { Template } from "tinacms";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { Prism } from "tinacms/dist/rich-text/prism";
 import { HoverCard } from "../util/hoverCard";
 
 export const Project = ({ data, tinaField, index }) => {
@@ -54,6 +55,7 @@ export const Projects = ({ data, parentField }) => {
           <TinaMarkdown
             content={data.body}
             data-tinafield={`${parentField}.body`}
+            components={{ code_block: Prism }}
           />
         </div>
         <div className={`flex flex-wrap gap-x-10 gap-y-8 text-left`}>

--- a/pages/blogs/[filename].tsx
+++ b/pages/blogs/[filename].tsx
@@ -5,6 +5,7 @@ import { Layout } from "../../components/layout";
 import { Section } from "../../components/util/section";
 import { Container } from "../../components/util/container";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { Prism } from "tinacms/dist/rich-text/prism";
 import { InferGetStaticPropsType } from "next";
 import Image from "next/image";
 import Head from "next/head";
@@ -80,7 +81,10 @@ export default function Blog(
           </Container>
           <Container className={`flex-1 pt-4`} width="small" size="large">
             <div className="prose dark:prose-dark w-full max-w-none">
-              <TinaMarkdown content={data.blog._body} />
+              <TinaMarkdown
+                content={data.blog._body}
+                components={{ code_block: Prism }}
+              />
             </div>
             <div>
               <Giscus


### PR DESCRIPTION
## Summary
- render fenced code blocks with syntax highlighting
- use TinaCMS Prism renderer across blog posts and blocks

## Testing
- `pnpm lint` *(fails: couldn't find ESLint config)*
- `pnpm build` *(fails: fetch failed during tina build)*

------
https://chatgpt.com/codex/tasks/task_e_686aea8791bc8327bbeee9a606d62eb4