### PR TITLE
Fix breadcrumb alignment and add SSW profile link to about page

### DIFF
--- a/components/layout/breadcrumb.tsx
+++ b/components/layout/breadcrumb.tsx
@@ -25,7 +25,7 @@ const NextBreadcrumb = () => {
   const pathNames = paths.split("/").filter((path) => path);
   return (
     pathNames.length > 0 && (
-      <div className="mx-20">
+      <div className="max-w-7xl mx-auto px-6 sm:px-8">
         <ul className="flex py-5">
           <li className="hover:opacity-70 hover:underline mx-2">
             <Link href={"/"} aria-label="Go to home page">

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -21,8 +21,13 @@ blocks:
       brings to innovation.
 
 
+      Check out my [SSW People
+      profile](https://www.ssw.com.au/people/brady-stroud/) for more about what
+      I do at work.
+
+
       Beyond the keyboard, you’ll usually find me far from my laptop - running,
-      mountain biking, climbing, or wakeboarding. Recently, I've been loving
+      mountain biking, climbing, or wakeboarding. Recently, I’ve been loving
       working on some renovation/new house construction projects with friends.
     highlights:
       - title: Cross-platform solutions


### PR DESCRIPTION
- Breadcrumb used mx-20 (fixed margin) which didn't align with page content. Now uses max-w-7xl mx-auto px-6 sm:px-8 to match the Container component.
- Add link to SSW People profile on the about page.